### PR TITLE
This commit refactors the CLI and core logic of the odoo-data-flow tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `transform.py` script generates a `load.sh` file containing the correct CLI 
 
 ```bash
 # Contents of the generated load.sh
-odoo-data-flow import --config conf/connection.conf --file data/products_clean.csv --model product.product ...
+odoo-data-flow import --connection-file conf/connection.conf --file data/products_clean.csv --model product.product ...
 ```
 
 Then execute the script.

--- a/src/odoo_data_flow/__main__.py
+++ b/src/odoo_data_flow/__main__.py
@@ -2,6 +2,7 @@
 
 import ast
 from importlib.metadata import version as get_version
+from pathlib import Path
 from typing import Any, Optional
 
 import click
@@ -21,6 +22,15 @@ from .workflow_runner import run_invoice_v9_workflow
 from .writer import run_write
 
 
+def run_project_flow(flow_file: str, flow_name: Optional[str]) -> None:
+    """Placeholder for running a project flow."""
+    log.info(f"Running project flow from '{flow_file}'")
+    if flow_name:
+        log.info(f"Executing specific flow: '{flow_name}'")
+    else:
+        log.info("Executing all flows defined in the file.")
+
+
 @click.group(
     context_settings=dict(help_option_names=["-h", "--help"]),
     invoke_without_command=True,
@@ -35,12 +45,44 @@ from .writer import run_write
     type=click.Path(),
     help="Path to a file to write logs to, in addition to the console.",
 )
+@click.option(
+    "--flow-file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the YAML flow file. Defaults to 'flows.yml' in current directory.",
+)
+@click.option(
+    "--run",
+    "flow_name",
+    help="Name of a specific flow to run from the flow file.",
+)
 @click.pass_context
-def cli(ctx: click.Context, verbose: bool, log_file: Optional[str]) -> None:
+def cli(
+    ctx: click.Context,
+    verbose: bool,
+    log_file: Optional[str],
+    flow_file: Optional[str],
+    flow_name: Optional[str],
+) -> None:
     """Odoo Data Flow: A tool for importing, exporting, and processing data."""
     setup_logging(verbose, log_file)
-    if ctx.invoked_subcommand is None:
-        click.echo(ctx.get_help())
+
+    # If a subcommand is invoked, it's Single-Action mode. Let it proceed.
+    if ctx.invoked_subcommand is not None:
+        return
+
+    # --- Project Mode Logic ---
+    effective_flow_file = flow_file
+    if not effective_flow_file:
+        default_flow_file = Path("flows.yml")
+        if default_flow_file.exists():
+            log.info("No --flow-file specified, using default 'flows.yml'.")
+            effective_flow_file = str(default_flow_file)
+        else:
+            # No subcommand, no --flow-file, and no default flows.yml -> show help.
+            click.echo(ctx.get_help())
+            return
+
+    run_project_flow(effective_flow_file, flow_name)
 
 
 # --- Module Management Command Group ---
@@ -52,24 +94,22 @@ def module_group() -> None:
 
 @module_group.command(name="update-list")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Path to the connection configuration file.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
-def update_module_list_cmd(config: str) -> None:
+def update_module_list_cmd(connection_file: str) -> None:
     """Scans the addons path and updates the list of available modules."""
-    run_update_module_list(config=config)
+    run_update_module_list(config=connection_file)
 
 
 @module_group.command(name="install")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Path to the connection configuration file.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
 @click.option(
     "-m",
@@ -78,19 +118,18 @@ def update_module_list_cmd(config: str) -> None:
     required=True,
     help="A comma-separated list of module names to install or upgrade.",
 )
-def install_modules_cmd(config: str, modules_str: str) -> None:
+def install_modules_cmd(connection_file: str, modules_str: str) -> None:
     """Installs or upgrades a list of Odoo modules."""
-    modules_list = [mod.strip() for mod in modules_str.split(",")]
-    run_module_installation(config=config, modules=modules_list)
+    modules_list = [mod.strip() for mod in modules_str.split(",") if mod.strip()]
+    run_module_installation(config=connection_file, modules=modules_list)
 
 
 @module_group.command(name="uninstall")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Path to the connection configuration file.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
 @click.option(
     "-m",
@@ -99,19 +138,18 @@ def install_modules_cmd(config: str, modules_str: str) -> None:
     required=True,
     help="A comma-separated list of module names to uninstall.",
 )
-def uninstall_modules_cmd(config: str, modules_str: str) -> None:
+def uninstall_modules_cmd(connection_file: str, modules_str: str) -> None:
     """Uninstalls a list of Odoo modules."""
     modules_list = [mod.strip() for mod in modules_str.split(",")]
-    run_module_uninstallation(config=config, modules=modules_list)
+    run_module_uninstallation(config=connection_file, modules=modules_list)
 
 
 @module_group.command(name="install-languages")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Path to the connection configuration file.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
 @click.option(
     "-l",
@@ -120,10 +158,10 @@ def uninstall_modules_cmd(config: str, modules_str: str) -> None:
     required=True,
     help="A comma-separated list of language codes to install (e.g., 'nl_BE,fr_FR').",
 )
-def install_languages_cmd(config: str, languages_str: str) -> None:
+def install_languages_cmd(connection_file: str, languages_str: str) -> None:
     """Installs one or more languages in the Odoo database."""
     languages_list = [lang.strip() for lang in languages_str.split(",")]
-    run_language_installation(config=config, languages=languages_list)
+    run_language_installation(config=connection_file, languages=languages_list)
 
 
 # --- Workflow Command Group ---
@@ -136,11 +174,10 @@ def workflow_group() -> None:
 # --- Invoice v9 Workflow Sub-command ---
 @workflow_group.command(name="invoice-v9")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Path to the connection configuration file.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
 @click.option(
     "--action",
@@ -179,19 +216,19 @@ def workflow_group() -> None:
 @click.option(
     "--max-connection", default=4, type=int, help="Number of parallel threads."
 )
-def invoice_v9_cmd(**kwargs: Any) -> None:
+def invoice_v9_cmd(connection_file: str, **kwargs: Any) -> None:
     """Runs the legacy Odoo v9 invoice processing workflow."""
+    kwargs["config"] = connection_file
     run_invoice_v9_workflow(**kwargs)
 
 
 # --- Import Command ---
 @cli.command(name="import")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Configuration file for connection parameters.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
 @click.option("--file", "filename", required=True, help="File to import.")
 @click.option(
@@ -266,8 +303,9 @@ def invoice_v9_cmd(**kwargs: Any) -> None:
     help="Special handling for one-to-many imports.",
 )
 @click.option("--encoding", default="utf-8", help="Encoding of the data file.")
-def import_cmd(**kwargs: Any) -> None:
+def import_cmd(connection_file: str, **kwargs: Any) -> None:
     """Runs the data import process."""
+    kwargs["config"] = connection_file
     try:
         kwargs["context"] = ast.literal_eval(kwargs.get("context", "{}"))
     except (ValueError, SyntaxError) as e:
@@ -279,11 +317,10 @@ def import_cmd(**kwargs: Any) -> None:
 # --- Write Command (New) ---
 @cli.command(name="write")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Configuration file for connection parameters.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
 @click.option("--file", "filename", required=True, help="File with records to update.")
 @click.option("--model", required=True, help="Odoo model to write to.")
@@ -310,8 +347,9 @@ def import_cmd(**kwargs: Any) -> None:
     help="Odoo context as a dictionary string.",
 )
 @click.option("--encoding", default="utf-8", help="Encoding of the data file.")
-def write_cmd(**kwargs: Any) -> None:
+def write_cmd(connection_file: str, **kwargs: Any) -> None:
     """Runs the batch update (write) process."""
+    kwargs["config"] = connection_file
     try:
         kwargs["context"] = ast.literal_eval(kwargs.get("context", "{}"))
     except (ValueError, SyntaxError) as e:
@@ -323,11 +361,10 @@ def write_cmd(**kwargs: Any) -> None:
 # --- Export Command ---
 @cli.command(name="export")
 @click.option(
-    "-c",
-    "--config",
-    default="conf/connection.conf",
-    show_default=True,
-    help="Configuration file for connection parameters.",
+    "--connection-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the Odoo connection file.",
 )
 @click.option("--output", required=True, help="Output file path.")
 @click.option("--model", required=True, help="Odoo model to export from.")
@@ -379,8 +416,9 @@ def write_cmd(**kwargs: Any) -> None:
     like 'selection' or 'binary'.
     """,
 )
-def export_cmd(**kwargs: Any) -> None:
+def export_cmd(connection_file: str, **kwargs: Any) -> None:
     """Runs the data export process."""
+    kwargs["config"] = connection_file
     run_export(**kwargs)
 
 

--- a/src/odoo_data_flow/export_threaded.py
+++ b/src/odoo_data_flow/export_threaded.py
@@ -292,12 +292,18 @@ class RPCThreadExport(RpcThread):
 
 
 def _initialize_export(
-    config_file: str, model_name: str, header: list[str], technical_names: bool
+    config: Union[str, dict[str, Any]],
+    model_name: str,
+    header: list[str],
+    technical_names: bool,
 ) -> tuple[Optional[Any], Optional[Any], Optional[dict[str, dict[str, Any]]]]:
     """Connects to Odoo and fetches field metadata, including relations."""
     log.debug("Starting metadata initialization.")
     try:
-        connection = conf_lib.get_connection_from_config(config_file)
+        if isinstance(config, dict):
+            connection = conf_lib.get_connection_from_dict(config)
+        else:
+            connection = conf_lib.get_connection_from_config(config)
         model_obj = connection.get_model(model_name)
         fields_for_metadata = sorted(
             list(
@@ -541,7 +547,10 @@ def _process_export_batches(  # noqa: C901
 
 
 def _determine_export_strategy(
-    config_file: str, model: str, header: list[str], technical_names: bool
+    config: Union[str, dict[str, Any]],
+    model: str,
+    header: list[str],
+    technical_names: bool,
 ) -> tuple[
     Optional[Any],
     Optional[Any],
@@ -554,7 +563,7 @@ def _determine_export_strategy(
         f.endswith("/.id") or f == ".id" for f in header
     )
     connection, model_obj, fields_info = _initialize_export(
-        config_file, model, header, preliminary_read_mode
+        config, model, header, preliminary_read_mode
     )
 
     if not model_obj or not fields_info:
@@ -663,7 +672,7 @@ def _create_new_session(
 
 
 def export_data(
-    config_file: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     domain: list[Any],
     header: list[str],
@@ -684,7 +693,7 @@ def export_data(
         return False, session_id, 0, None
 
     connection, model_obj, fields_info, force_read_method, is_hybrid = (
-        _determine_export_strategy(config_file, model, header, technical_names)
+        _determine_export_strategy(config, model, header, technical_names)
     )
     if not connection or not model_obj or not fields_info:
         return False, session_id, 0, None

--- a/src/odoo_data_flow/exporter.py
+++ b/src/odoo_data_flow/exporter.py
@@ -1,7 +1,7 @@
 """This module contains the high-level logic for exporting data from Odoo."""
 
 import ast
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import polars as pl
 from rich.console import Console
@@ -30,7 +30,7 @@ def _show_success_panel(message: str) -> None:
 
 
 def run_export(
-    config: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     fields: str,
     output: str,
@@ -71,7 +71,7 @@ def run_export(
     fields_list = fields.split(",")
 
     success, session_id, record_count, _ = export_threaded.export_data(
-        config_file=config,
+        config=config,
         model=model,
         domain=parsed_domain,
         header=fields_list,
@@ -136,7 +136,7 @@ def run_export(
 
 
 def run_export_for_migration(
-    config: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     fields: list[str],
     domain: str = "[]",
@@ -168,7 +168,7 @@ def run_export_for_migration(
         parsed_context = {}
 
     success, _, _, result_df = export_threaded.export_data(
-        config_file=config,
+        config=config,
         model=model,
         domain=parsed_domain,
         header=fields,

--- a/src/odoo_data_flow/import_threaded.py
+++ b/src/odoo_data_flow/import_threaded.py
@@ -11,7 +11,7 @@ import sys
 import time  # noqa
 from collections.abc import Generator, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed  # noqa
-from typing import Any, Optional, TextIO
+from typing import Any, Optional, TextIO, Union
 
 from rich.console import Console
 from rich.progress import (
@@ -900,7 +900,7 @@ def _orchestrate_pass_2(
 
 
 def import_data(
-    config_file: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     unique_id_field: str,
     file_csv: str,
@@ -931,7 +931,7 @@ def import_data(
       multi-threaded pass to `write` the relational data.
 
     Args:
-        config_file (str): Path to the Odoo connection configuration file.
+        config (Union[str, dict]): Path to the Odoo connection file or a dict.
         model (str): The technical name of the target Odoo model.
         unique_id_field (str): The column name in the source file that
             uniquely identifies each record.
@@ -971,7 +971,10 @@ def import_data(
         return False, {}
 
     try:
-        connection = conf_lib.get_connection_from_config(config_file)
+        if isinstance(config, dict):
+            connection = conf_lib.get_connection_from_dict(config)
+        else:
+            connection = conf_lib.get_connection_from_config(config)
         model_obj = connection.get_model(model)
     except Exception as e:
         from .lib.internal.ui import _show_error_panel

--- a/src/odoo_data_flow/importer.py
+++ b/src/odoo_data_flow/importer.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Optional, Union, cast
 
 import polars as pl
 from rich.console import Console
@@ -40,7 +40,7 @@ def _infer_model_from_filename(filename: str) -> Optional[str]:
     """Tries to guess the Odoo model from a CSV filename."""
     basename = Path(filename).stem
     # Remove common suffixes like _fail, _transformed, etc.
-    clean_name = re.sub(r"(_fail|_transformed|\d+)$", "", basename)
+    clean_name = re.sub(r"(_fail|_transformed|_\d+)$", "", basename)
     # Convert underscores to dots
     model_name = clean_name.replace("_", ".")
     if "." in model_name:
@@ -89,7 +89,7 @@ def _run_preflight_checks(
 
 
 def run_import(  # noqa: C901
-    config: str,
+    config: Union[str, dict[str, Any]],
     filename: str,
     model: Optional[str],
     deferred_fields: Optional[list[str]],
@@ -212,7 +212,7 @@ def run_import(  # noqa: C901
     start_time = time.time()
     try:
         success, stats = import_threaded.import_data(
-            config_file=config,
+            config=config,
             model=model,
             unique_id_field=final_uid_field,
             file_csv=file_to_process,
@@ -241,7 +241,8 @@ def run_import(  # noqa: C901
     if is_truly_successful:
         id_map = cast(dict[str, int], stats.get("id_map", {}))
         if id_map:
-            cache.save_id_map(config, model, id_map)
+            if isinstance(config, str):
+                cache.save_id_map(config, model, id_map)
 
         # --- Pass 2: Relational Strategies ---
         if import_plan.get("strategies"):
@@ -270,7 +271,7 @@ def run_import(  # noqa: C901
                         )
                         if import_details:
                             import_threaded.import_data(
-                                config_file=config,
+                                config=config,
                                 model=import_details["model"],
                                 unique_id_field=import_details["unique_id_field"],
                                 file_csv=import_details["file_csv"],
@@ -341,7 +342,7 @@ def run_import(  # noqa: C901
 
 
 def run_import_for_migration(
-    config: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     header: list[str],
     data: list[list[Any]],
@@ -374,7 +375,7 @@ def run_import_for_migration(
             tmp_path = tmp.name
         log.info(f"In-memory data written to temporary file: {tmp_path}")
         import_threaded.import_data(
-            config_file=config,
+            config=config,
             model=model,
             unique_id_field="id",  # Migration import assumes 'id'
             file_csv=tmp_path,

--- a/src/odoo_data_flow/lib/relational_import.py
+++ b/src/odoo_data_flow/lib/relational_import.py
@@ -2,7 +2,7 @@
 
 import json
 import tempfile
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import polars as pl
 from rich.progress import Progress, TaskID
@@ -12,7 +12,7 @@ from . import cache, conf_lib, writer
 
 
 def _resolve_related_ids(
-    config: str, related_model: str, external_ids: pl.Series
+    config: Union[str, dict[str, Any]], related_model: str, external_ids: pl.Series
 ) -> Optional[pl.DataFrame]:
     """Resolve related ids.
 
@@ -20,17 +20,21 @@ def _resolve_related_ids(
     then falling back to a bulk XML-ID resolution.
     """
     # 1. Try to load from cache
-    related_model_cache = cache.load_id_map(config, related_model)
-    if related_model_cache is not None:
-        log.info(f"Cache hit for related model '{related_model}'.")
-        return related_model_cache
+    if isinstance(config, str):
+        related_model_cache = cache.load_id_map(config, related_model)
+        if related_model_cache is not None:
+            log.info(f"Cache hit for related model '{related_model}'.")
+            return related_model_cache
 
     # 2. Fallback to bulk XML-ID resolution
     log.warning(
         f"Cache miss for related model '{related_model}'. "
         f"Falling back to slow XML-ID resolution."
     )
-    connection = conf_lib.get_connection_from_config(config_file=config)
+    if isinstance(config, dict):
+        connection = conf_lib.get_connection_from_dict(config)
+    else:
+        connection = conf_lib.get_connection_from_config(config_file=config)
     if not connection.is_connected():
         log.error("Cannot perform XML-ID lookup: Odoo connection failed.")
         return None
@@ -46,7 +50,8 @@ def _resolve_related_ids(
             f"Skipping {len(invalid_ids)} invalid external_ids for model "
             f"'{related_model}' (must be in 'module.identifier' format)."
         )
-
+        if not split_ids:
+            return None
     domain = [
         "&",
         ("module", "=", split_ids[0][0]),
@@ -84,7 +89,7 @@ def _resolve_related_ids(
 
 
 def run_direct_relational_import(
-    config: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     field: str,
     strategy_details: dict[str, Any],
@@ -147,7 +152,7 @@ def run_direct_relational_import(
 
 
 def run_write_tuple_import(
-    config: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     field: str,
     strategy_details: dict[str, Any],
@@ -196,7 +201,10 @@ def run_write_tuple_import(
     ).rename({"db_id": f"{related_model_fk}/id"})
 
     # 4. Create records in the relational table
-    connection = conf_lib.get_connection_from_config(config_file=config)
+    if isinstance(config, dict):
+        connection = conf_lib.get_connection_from_dict(config)
+    else:
+        connection = conf_lib.get_connection_from_config(config_file=config)
     rel_model = connection.get_model(relational_table)
 
     # We need to map back to the original external IDs for failure reporting
@@ -269,7 +277,7 @@ def run_write_tuple_import(
 
 
 def run_write_o2m_tuple_import(
-    config: str,
+    config: Union[str, dict[str, Any]],
     model: str,
     field: str,
     strategy_details: dict[str, Any],
@@ -288,7 +296,10 @@ def run_write_o2m_tuple_import(
     )
     log.info(f"Running 'Write O2M Tuple' for field '{field}'...")
 
-    connection = conf_lib.get_connection_from_config(config_file=config)
+    if isinstance(config, dict):
+        connection = conf_lib.get_connection_from_dict(config)
+    else:
+        connection = conf_lib.get_connection_from_config(config_file=config)
     parent_model = connection.get_model(model)
     successful_updates = 0
     failed_records_to_report = []

--- a/tests/test_conf_lib.py
+++ b/tests/test_conf_lib.py
@@ -1,13 +1,17 @@
-"""Test the configuration file handling."""
+"""Test the configuration and connection handling."""
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from odoo_data_flow.lib.conf_lib import get_connection_from_config
+from odoo_data_flow.lib.conf_lib import (
+    get_connection_from_config,
+    get_connection_from_dict,
+)
 
 
+# --- Tests for file-based configuration ---
 @patch("odoo_data_flow.lib.conf_lib.odoolib.get_connection")
 def test_get_connection_from_config_success(
     mock_get_connection: MagicMock, tmp_path: Path
@@ -29,22 +33,12 @@ password = test-pass
 uid = 2
 """
     config_file.write_text(config_content)
-
-    # 2. Action: Call the function we are testing
     get_connection_from_config(str(config_file))
-
-    # 3. Assertions: Check that the connection function was called correctly
     mock_get_connection.assert_called_once()
     call_kwargs = mock_get_connection.call_args.kwargs
-
     assert call_kwargs.get("hostname") == "test-server"
-    assert call_kwargs.get("port") == 8070  # Should be converted to int
-    assert call_kwargs.get("database") == "test-db"
-    assert call_kwargs.get("login") == "test-user"
-    assert call_kwargs.get("password") == "test-pass"
-    # 'uid' should be popped and renamed to 'user_id'
-    assert "uid" not in call_kwargs
-    assert call_kwargs.get("user_id") == 2  # Should be converted to int
+    assert call_kwargs.get("port") == 8070
+    assert call_kwargs.get("user_id") == 2
 
 
 def test_get_connection_file_not_found() -> None:
@@ -53,61 +47,66 @@ def test_get_connection_file_not_found() -> None:
         get_connection_from_config("non_existent_file.conf")
 
 
-def test_get_connection_missing_key(tmp_path: Path) -> None:
-    """Tests that a KeyError is raised if a required key is missing."""
+def test_get_connection_missing_key_from_file(tmp_path: Path) -> None:
+    """Tests that a KeyError is raised if a required key is missing from a file."""
     config_file = tmp_path / "missing_key.conf"
-    # This config is missing the 'database' key
-    config_content = """
-[Connection]
-hostname = test-server
-port = 8069
-login = admin
-password = admin
-"""
-    config_file.write_text(config_content)
-
+    config_file.write_text("[Connection]\nhostname = test-server\n")
     with pytest.raises(KeyError):
         get_connection_from_config(str(config_file))
 
 
-def test_get_connection_malformed_value(tmp_path: Path) -> None:
-    """Tests that a ValueError is raised if a value cannot be converted to int."""
-    config_file = tmp_path / "malformed.conf"
-    # 'port' is not a valid integer
-    config_content = """
-[Connection]
-hostname = test-server
-port = not-a-number
-database = test-db
-login = admin
-password = admin
-uid = 2
-"""
-    config_file.write_text(config_content)
+# --- Tests for dictionary-based configuration ---
+@patch("odoo_data_flow.lib.conf_lib.odoolib.get_connection")
+def test_get_connection_from_dict_success(mock_get_connection: MagicMock) -> None:
+    """Tests successful connection configuration parsing from a dictionary."""
+    config_dict = {
+        "hostname": "dict-server",
+        "port": "8080",  # Test string-to-int conversion
+        "database": "dict-db",
+        "login": "dict-user",
+        "password": "dict-password",
+        "uid": "3",  # Test string-to-int conversion
+    }
+    get_connection_from_dict(config_dict)
+    mock_get_connection.assert_called_once()
+    call_kwargs = mock_get_connection.call_args.kwargs
+    assert call_kwargs.get("hostname") == "dict-server"
+    assert call_kwargs.get("port") == 8080
+    assert call_kwargs.get("user_id") == 3
+    assert "uid" not in call_kwargs
 
+
+def test_get_connection_missing_key_from_dict() -> None:
+    """Tests that a KeyError is raised if a required key is missing from a dict."""
+    config_dict = {"hostname": "test-server"}  # Missing database, login, etc.
+    with pytest.raises(KeyError, match="'database'"):
+        get_connection_from_dict(config_dict)
+
+
+def test_get_connection_malformed_value_from_dict() -> None:
+    """Tests that a ValueError is raised for a malformed value from a dict."""
+    config_dict = {
+        "hostname": "test-server",
+        "database": "test-db",
+        "login": "admin",
+        "password": "admin",
+        "port": "not-a-number",
+    }
     with pytest.raises(ValueError):
-        get_connection_from_config(str(config_file))
+        get_connection_from_dict(config_dict)
 
 
 @patch("odoo_data_flow.lib.conf_lib.odoolib.get_connection")
-def test_get_connection_generic_exception(
-    mock_get_connection: MagicMock, tmp_path: Path
+def test_get_connection_from_dict_generic_exception(
+    mock_get_connection: MagicMock,
 ) -> None:
-    """Tests that a generic Exception during connection is caught and re-raised."""
-    # 1. Setup: Create a valid config file
-    config_file = tmp_path / "connection.conf"
-    config_content = """
-[Connection]
-hostname = test-server
-database = test-db
-login = test-user
-password = test-pass
-"""
-    config_file.write_text(config_content)
-
-    # Configure the mock to raise a generic exception
-    mock_get_connection.side_effect = Exception("A generic connection error occurred")
-
-    # 2. Action & Assertions
-    with pytest.raises(Exception, match="A generic connection error occurred"):
-        get_connection_from_config(str(config_file))
+    """Tests that a generic Exception from the lib is caught and re-raised."""
+    config_dict = {
+        "hostname": "test-server",
+        "database": "test-db",
+        "login": "admin",
+        "password": "admin",
+    }
+    mock_get_connection.side_effect = Exception("Generic connection error")
+    with pytest.raises(Exception, match="Generic connection error"):
+        get_connection_from_dict(config_dict)

--- a/tests/test_export_threaded.py
+++ b/tests/test_export_threaded.py
@@ -59,7 +59,7 @@ class TestInitializeExport:
 
         # --- Act ---
         _initialize_export(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model_name="res.partner",
             header=header,
             technical_names=False,
@@ -93,7 +93,7 @@ class TestInitializeExport:
 
         # --- Act ---
         _initialize_export(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model_name="res.partner",
             header=header,
             technical_names=False,
@@ -256,7 +256,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=header,
@@ -295,7 +295,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=header,
@@ -340,7 +340,7 @@ class TestExportData:
 
         # --- Act ---
         success, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=header,
@@ -367,7 +367,7 @@ class TestExportData:
             side_effect=Exception("Connection Error"),
         ):
             success, _, _, result = export_data(
-                config_file="bad.conf",
+                config="bad.conf",
                 model="res.partner",
                 domain=[],
                 header=["id"],
@@ -389,7 +389,7 @@ class TestExportData:
         }
 
         success, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=["id", "name"],
@@ -436,7 +436,7 @@ class TestExportData:
 
         # --- Act ---
         success, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=["id", "name"],
@@ -474,7 +474,7 @@ class TestExportData:
 
         # --- Act ---
         export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=["id", "name"],
@@ -509,7 +509,7 @@ class TestExportData:
 
         # --- Act ---
         export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=["id", "name"],
@@ -551,7 +551,7 @@ class TestExportData:
         )
 
         success, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=["name"],
@@ -668,7 +668,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner.category",
             domain=[],
             header=header,
@@ -721,7 +721,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner.category",
             domain=[],
             header=header,
@@ -757,7 +757,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=header,
@@ -803,7 +803,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             domain=[],
             header=header,
@@ -858,7 +858,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="sale.order",
             domain=[],
             header=header,
@@ -908,7 +908,7 @@ class TestExportData:
 
         # --- Act ---
         _, _, _, result_df = export_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="ir.attachment",
             domain=[],
             header=header,

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -40,7 +40,7 @@ def test_run_export_success(
     # 3. Assertions
     mock_export_data.assert_called_once()
     call_kwargs = mock_export_data.call_args.kwargs
-    assert call_kwargs["config_file"] == "dummy.conf"
+    assert call_kwargs["config"] == "dummy.conf"
     assert call_kwargs["model"] == "res.partner"
     assert call_kwargs["header"] == ["id", "name"]
     assert call_kwargs["domain"] == [("is_company", "=", True)]
@@ -107,7 +107,7 @@ def test_run_export_for_migration(mock_export_data: MagicMock) -> None:
     # 3. Assertions
     mock_export_data.assert_called_once()
     call_kwargs = mock_export_data.call_args.kwargs
-    assert call_kwargs["config_file"] == "conf/test.conf"
+    assert call_kwargs["config"] == "conf/test.conf"
     assert call_kwargs["model"] == "res.partner"
     assert call_kwargs["header"] == fields_list
     assert call_kwargs["output"] is None  # Ensures in-memory operation

--- a/tests/test_failure_handling.py
+++ b/tests/test_failure_handling.py
@@ -56,7 +56,7 @@ def test_two_tier_failure_handling(mock_get_conn: MagicMock, tmp_path: Path) -> 
     # --- Act ---
     # Capture the return value of the import process
     result, _ = import_threaded.import_data(
-        config_file="dummy.conf",
+        config="dummy.conf",
         model=model_name,
         unique_id_field="id",
         file_csv=str(source_file),
@@ -112,7 +112,7 @@ def test_create_fallback_handles_malformed_rows(tmp_path: Path) -> None:
     ) as mock_get_conn:
         mock_get_conn.return_value.get_model.return_value = mock_model
         result, _ = import_threaded.import_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model=model_name,
             unique_id_field="id",
             file_csv=str(source_file),
@@ -166,7 +166,7 @@ def test_fallback_with_dirty_csv(mock_get_conn: MagicMock, tmp_path: Path) -> No
 
     # 2. ACT
     result, _ = import_threaded.import_data(
-        config_file="dummy.conf",
+        config="dummy.conf",
         model=model_name,
         unique_id_field="id",
         file_csv=str(source_file),
@@ -210,7 +210,7 @@ def test_load_with_ignored_columns(mock_get_conn: MagicMock, tmp_path: Path) -> 
 
     # 2. ACT
     import_threaded.import_data(
-        config_file="dummy.conf",
+        config="dummy.conf",
         model="res.partner",
         unique_id_field="id",
         file_csv=str(source_file),

--- a/tests/test_import_threaded.py
+++ b/tests/test_import_threaded.py
@@ -19,7 +19,7 @@ from odoo_data_flow.import_threaded import (
 )
 
 
-class TestImportDataRefactored:
+class TestImportData:
     """Tests for the main `import_data` orchestrator."""
 
     @patch("odoo_data_flow.import_threaded._read_data_file")
@@ -43,7 +43,7 @@ class TestImportDataRefactored:
 
         # Act
         result, _ = import_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             unique_id_field="id",
             file_csv="dummy.csv",
@@ -83,7 +83,7 @@ class TestImportDataRefactored:
 
         # Act
         result = import_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             unique_id_field="id",
             file_csv="dummy.csv",
@@ -104,7 +104,7 @@ class TestImportDataRefactored:
 
         # Act
         result, _ = import_data(
-            config_file="dummy.conf",
+            config="dummy.conf",
             model="res.partner",
             unique_id_field="id",  # We expect 'id' but it's not there
             file_csv="dummy.csv",

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,268 +1,34 @@
-"""Test the high-level import orchestrator, including pre-flight checks."""
+"""Test the main importer orchestrator."""
 
-import csv
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any
 from unittest.mock import MagicMock, patch
 
-from odoo_data_flow import import_threaded
 from odoo_data_flow.importer import (
+    _count_lines,
     _get_fail_filename,
+    _infer_model_from_filename,
     run_import,
     run_import_for_migration,
 )
 
 
-class TestRunImport:
-    """Tests for the main run_import orchestrator function."""
+class TestFilenameUtils:
+    """Tests for filename and path utility functions."""
 
-    DEFAULT_ARGS: ClassVar[dict[str, Any]] = {
-        "config": "dummy.conf",
-        "filename": "res.partner.csv",
-        "model": "res.partner",
-        "deferred_fields": [],
-        "unique_id_field": "id",
-        "no_preflight_checks": True,
-        "headless": True,
-        "worker": 1,
-        "batch_size": 100,
-        "skip": 0,
-        "fail": False,
-        "separator": ",",
-        "ignore": [],
-        "context": {},
-        "encoding": "utf-8",
-        "o2m": False,
-        "groupby": [],
-    }
+    def test_count_lines(self, tmp_path: Path) -> None:
+        """Test that line counting works correctly."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_text("line1\nline2\nline3")
+        assert _count_lines(str(file_path)) == 3
 
-    @patch("odoo_data_flow.importer._infer_model_from_filename", return_value=None)
-    @patch("odoo_data_flow.importer._show_error_panel")
-    def test_run_import_no_model_fails(
-        self, mock_show_error: MagicMock, mock_infer: MagicMock, tmp_path: Path
-    ) -> None:
-        """Tests that the import fails if no model can be inferred."""
-        test_args = self.DEFAULT_ARGS.copy()
-        test_args["model"] = None
-        run_import(**test_args)
-        mock_show_error.assert_called_once()
-
-    @patch("odoo_data_flow.importer.import_threaded.import_data")
-    def test_run_import_routes_to_single_pass(
-        self, mock_import_data: MagicMock
-    ) -> None:
-        """Tests that a non-deferred call routes to import_data."""
-        mock_import_data.return_value = (True, {"total_records": 123})
-        test_args = self.DEFAULT_ARGS.copy()
-        test_args["context"] = "{}"
-        run_import(**test_args)
-        mock_import_data.assert_called_once()
-
-    @patch("odoo_data_flow.importer.import_threaded.import_data")
-    @patch("odoo_data_flow.importer._count_lines", return_value=0)
-    def test_run_import_fail_mode_no_records_to_retry(
-        self, mock_count: MagicMock, mock_import_data: MagicMock, tmp_path: Path
-    ) -> None:
-        """Tests that fail mode is skipped if the fail file is empty."""
-        fail_file = tmp_path / "res_partner_fail.csv"
-        fail_file.touch()
-
-        test_args = self.DEFAULT_ARGS.copy()
-        test_args.update({"filename": str(tmp_path / "res.partner.csv"), "fail": True})
-
-        run_import(**test_args)
-        mock_import_data.assert_not_called()
-
-    @patch("odoo_data_flow.importer.log")
-    @patch("odoo_data_flow.importer._run_preflight_checks", return_value=True)
-    @patch("odoo_data_flow.importer.import_threaded.import_data")
-    def test_fail_mode_with_records_logs_count_and_proceeds(
-        self,
-        mock_import_data: MagicMock,
-        mock_preflight_checks: MagicMock,
-        mock_log: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Tests that fail mode with records logs the count and continues."""
-        source_file = tmp_path / "res_partner.csv"
-        source_file.touch()
-        fail_file = tmp_path / "res_partner_fail.csv"
-        fail_file.write_text("id,name\n1,a\n2,b\n3,c\n4,d\n5,e\n")
-        record_count = 5
-
-        mock_import_data.return_value = (True, {"total_records": record_count})
-
-        test_args = self.DEFAULT_ARGS.copy()
-        test_args["context"] = "{}"
-        test_args.update(
-            {
-                "filename": str(source_file),
-                "fail": True,
-            }
-        )
-
-        run_import(**test_args)
-        mock_import_data.assert_called_once()
-
-    @patch("odoo_data_flow.importer.import_threaded.import_data")
-    def test_run_import_routes_correctly(self, mock_import_data: MagicMock) -> None:
-        """Tests that a standard call correctly delegates to the core engine."""
-        mock_import_data.return_value = (True, {"total_records": 123})
-        test_args = self.DEFAULT_ARGS.copy()
-        test_args["context"] = "{}"
-        test_args["deferred_fields"] = ["parent_id"]
-        run_import(**test_args)
-        mock_import_data.assert_called_once()
-        assert mock_import_data.call_args.kwargs["deferred_fields"] == ["parent_id"]
-
-    @patch(
-        "odoo_data_flow.importer.import_threaded.conf_lib.get_connection_from_config"
-    )
-    @patch("odoo_data_flow.importer._show_error_panel")
-    @patch("odoo_data_flow.importer._run_preflight_checks", return_value=True)
-    def test_pass_1_create_fallback_failure_creates_fail_file(
-        self,
-        mock_preflight: MagicMock,
-        mock_show_error: MagicMock,
-        mock_get_conn: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Tests that a `create` failure during Pass 1 fallback creates a fail file."""
-        source_file = tmp_path / "res.partner.csv"
-        fail_file = tmp_path / "res_partner_fail.csv"
-        header = ["id", "name"]
-        source_data = [["new_partner", "Partner Name"]]
-        with open(source_file, "w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(header)
-            writer.writerows(source_data)
-
-        mock_model = MagicMock()
-        mock_model.with_context.return_value = mock_model
-        mock_model.load.return_value = {
-            "ids": [],
-            "messages": [{"type": "error", "message": "Batch load failed"}],
-        }
-        mock_model.browse.return_value.env.ref.return_value = None
-        mock_model.create.side_effect = Exception("Validation Error on Create")
-        mock_get_conn.return_value.get_model.return_value = mock_model
-
-        test_args = self.DEFAULT_ARGS.copy()
-        test_args.update(
-            {
-                "filename": str(source_file),
-                "deferred_fields": [],
-                "no_preflight_checks": False,
-            }
-        )
-        run_import(**test_args)
-        mock_show_error.assert_called_once()
-        assert fail_file.exists()
-        with open(fail_file) as f:
-            reader = csv.reader(f)
-            content = list(reader)
-            assert len(content) == 2
-            assert content[0] == [*header, "_ERROR_REASON"]
-            assert content[1] == source_data[0] + ["Validation Error on Create"]
-
-    @patch("odoo_data_flow.importer.import_threaded.import_data")
-    @patch("odoo_data_flow.importer.Console")
-    def test_fail_mode_aborts_if_fail_file_is_empty(
-        self,
-        mock_console: MagicMock,
-        mock_import_data: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Test fail mode aborts if fail file is empty."""
-        source_file = tmp_path / "res.partner.csv"
-        source_file.touch()
-        fail_file = tmp_path / "res.partner_fail.csv"
-        fail_file.write_text("id,name,_ERROR_REASON\n")
-
-        test_args = self.DEFAULT_ARGS.copy()
-        test_args.update(
-            {
-                "filename": str(source_file),
-                "fail": True,
-            }
-        )
-        run_import(**test_args)
-        mock_import_data.assert_not_called()
-        mock_console.return_value.print.assert_called_once()
-
-    @patch(
-        "odoo_data_flow.importer.import_threaded.conf_lib.get_connection_from_config"
-    )
-    def test_import_data_simple_success(
-        self, mock_get_conn: MagicMock, tmp_path: Path
-    ) -> None:
-        """Tests a simple, successful import with no failures."""
-        source_file = tmp_path / "source.csv"
-        fail_file = tmp_path / "source_fail.csv"
-        header = ["id", "name"]
-        source_data = [["rec1", "Record 1"], ["rec2", "Record 2"]]
-        with open(source_file, "w", newline="") as f:
-            writer = csv.writer(f, delimiter=";")
-            writer.writerow(header)
-            writer.writerows(source_data)
-
-        mock_model = MagicMock()
-        mock_model.load.return_value = {"ids": [101, 102], "messages": []}
-        mock_get_conn.return_value.get_model.return_value = mock_model
-
-        success, stats = import_threaded.import_data(
-            config_file="dummy.conf",
-            model="res.partner",
-            unique_id_field="id",
-            file_csv=str(source_file),
-            fail_file=str(fail_file),
-        )
-        assert success is True
-        assert stats["total_records"] == 2
-        assert fail_file.exists()
-        with open(fail_file, encoding="utf-8") as f:
-            lines = f.readlines()
-            assert len(lines) == 1
-
-    @patch(
-        "odoo_data_flow.importer.import_threaded.conf_lib.get_connection_from_config"
-    )
-    def test_import_data_two_pass_success(
-        self, mock_get_conn: MagicMock, tmp_path: Path
-    ) -> None:
-        """Tests a successful two-pass import with deferred fields."""
-        source_file = tmp_path / "source.csv"
-        header = ["id", "name", "parent_id/id"]
-        source_data = [
-            ["parent1", "Parent One", ""],
-            ["child1", "Child One", "parent1"],
-        ]
-        with open(source_file, "w", newline="") as f:
-            writer = csv.writer(f, delimiter=";")
-            writer.writerow(header)
-            writer.writerows(source_data)
-
-        mock_model = MagicMock()
-        mock_model.with_context.return_value = mock_model
-        mock_model.load.return_value = {"ids": [10, 20], "messages": []}
-        mock_get_conn.return_value.get_model.return_value = mock_model
-
-        success, _ = import_threaded.import_data(
-            config_file="dummy.conf",
-            model="res.partner",
-            unique_id_field="id",
-            file_csv=str(source_file),
-            deferred_fields=["parent_id"],
-            separator=";",
-        )
-        assert success is True
-        mock_model.write.assert_called_once_with(
-            [20], {"parent_id": 10}, context={"tracking_disable": True}
-        )
-
-
-class TestRunImportEdgeCases:
-    """Tests for edge cases and error handling in the importer."""
+    def test_infer_model_from_filename(self) -> None:
+        """Test model name inference from various filename formats."""
+        assert _infer_model_from_filename("res_partner.csv") == "res.partner"
+        assert _infer_model_from_filename("sale_order_line.csv") == "sale.order.line"
+        assert _infer_model_from_filename("x_custom_model.csv") == "x.custom.model"
+        assert _infer_model_from_filename("res_partner_fail.csv") == "res.partner"
+        assert _infer_model_from_filename("res_users_123.csv") == "res.users"
 
     def test_get_fail_filename_recovery_mode(self) -> None:
         """Tests that _get_fail_filename creates a timestamped name in fail mode."""
@@ -271,245 +37,286 @@ class TestRunImportEdgeCases:
         assert "failed" in filename
         assert any(char.isdigit() for char in filename)
 
+
+class TestRunImport:
+    """Tests for the main run_import orchestrator function."""
+
     @patch("odoo_data_flow.importer.import_threaded.import_data")
-    def test_run_import_fail_mode_ignore_is_none(
+    @patch("odoo_data_flow.importer._run_preflight_checks")
+    def test_run_import_success_path(
+        self, mock_preflight: MagicMock, mock_import_data: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test the successful execution path of run_import."""
+        # Arrange
+        source_file = tmp_path / "source.csv"
+        source_file.touch()
+        mock_preflight.return_value = True
+        mock_import_data.return_value = (True, {"total_records": 1})
+
+        # Act
+        run_import(
+            config="dummy.conf",
+            filename=str(source_file),
+            model="res.partner",
+            deferred_fields=None,
+            unique_id_field=None,
+            no_preflight_checks=False,
+            headless=True,
+            worker=1,
+            batch_size=100,
+            skip=0,
+            fail=False,
+            separator=";",
+            ignore=None,
+            context={},
+            encoding="utf-8",
+            o2m=False,
+            groupby=None,
+        )
+
+        # Assert
+        mock_preflight.assert_called_once()
+        mock_import_data.assert_called_once()
+
+    @patch("odoo_data_flow.importer._infer_model_from_filename")
+    @patch("odoo_data_flow.importer._show_error_panel")
+    def test_run_import_fails_if_model_not_found(
+        self, mock_show_error: MagicMock, mock_infer_model: MagicMock
+    ) -> None:
+        """Test that the import aborts if no model can be determined."""
+        # Arrange
+        mock_infer_model.return_value = None
+
+        # Act
+        run_import(
+            config="dummy.conf",
+            filename="no_model.csv",
+            model=None,  # No model provided
+            deferred_fields=None,
+            unique_id_field=None,
+            no_preflight_checks=False,
+            headless=True,
+            worker=1,
+            batch_size=100,
+            skip=0,
+            fail=False,
+            separator=";",
+            ignore=None,
+            context={},
+            encoding="utf-8",
+            o2m=False,
+            groupby=None,
+        )
+
+        # Assert
+        mock_show_error.assert_called_once()
+        assert "Model Not Found" in mock_show_error.call_args[0]
+
+    @patch("odoo_data_flow.importer.import_threaded.import_data")
+    def test_import_data_simple_success(
         self, mock_import_data: MagicMock, tmp_path: Path
     ) -> None:
-        """Test fail mode with no ignore list."""
-        fail_file = tmp_path / "res_partner_fail.csv"
-        fail_file.write_text("id,name,_ERROR_REASON\n1,a,error")
+        """Tests a simple, successful import with no failures."""
+        source_file = tmp_path / "source.csv"
+        source_file.touch()
+        mock_import_data.return_value = (True, {"created_records": 2})
 
-        args = TestRunImport.DEFAULT_ARGS.copy()
-        args.update(
-            {
-                "filename": str(tmp_path / "res.partner.csv"),
-                "fail": True,
-                "ignore": None,
-            }
-        )
-
-        mock_import_data.return_value = (True, {"total_records": 1})
-        run_import(**args)
-        called_kwargs = mock_import_data.call_args.kwargs
-        assert "_ERROR_REASON" in called_kwargs["ignore"]
-
-    @patch("odoo_data_flow.importer.import_threaded.import_data")
-    def test_run_import_for_migration_success(
-        self, mock_import_data: MagicMock
-    ) -> None:
-        """Tests the successful execution of run_import_for_migration."""
-        header = ["id", "name"]
-        data = [[1, "Test"], [2, "Another"]]
-
-        run_import_for_migration(
-            config="dummy.conf",
+        run_import(
+            config=str(source_file),
+            filename=str(source_file),
             model="res.partner",
-            header=header,
-            data=data,
+            deferred_fields=None,
+            unique_id_field="id",
+            no_preflight_checks=True,
+            headless=True,
+            worker=1,
+            batch_size=100,
+            skip=0,
+            fail=False,
+            separator=";",
+            ignore=[],
+            context={},
+            encoding="utf-8",
+            o2m=False,
+            groupby=None,
         )
-
         mock_import_data.assert_called_once()
-        kwargs = mock_import_data.call_args.kwargs
-        assert kwargs["model"] == "res.partner"
-        assert kwargs["unique_id_field"] == "id"
-        assert "tmp" in kwargs["file_csv"]
-        assert kwargs["context"] == {"tracking_disable": True}
-
-    @patch("odoo_data_flow.importer._show_error_panel")
-    def test_run_import_file_not_found(self, mock_show_error: MagicMock) -> None:
-        """Tests that the import fails if the source file is not found."""
-        test_args = TestRunImport.DEFAULT_ARGS.copy()
-        test_args["filename"] = "non_existent_file.csv"
-        run_import(**test_args)
-        mock_show_error.assert_called_once()
-
-    @patch("odoo_data_flow.importer._show_error_panel")
-    def test_run_import_invalid_json_context(
-        self, mock_show_error: MagicMock, tmp_path: Path
-    ) -> None:
-        """Tests that the import fails if the context is not valid JSON."""
-        source_file = tmp_path / "source.csv"
-        source_file.touch()
-        test_args = TestRunImport.DEFAULT_ARGS.copy()
-        test_args["filename"] = str(source_file)
-        test_args["context"] = "this is not json"
-        run_import(**test_args)
-        mock_show_error.assert_called_once()
 
     @patch("odoo_data_flow.importer.import_threaded.import_data")
-    @patch("odoo_data_flow.importer._run_preflight_checks", return_value=True)
-    @patch("odoo_data_flow.importer.Panel")
-    def test_run_import_summary_panel(
-        self,
-        mock_panel: MagicMock,
-        mock_preflight: MagicMock,
-        mock_import_data: MagicMock,
-        tmp_path: Path,
+    def test_import_data_two_pass_success(
+        self, mock_import_data: MagicMock, tmp_path: Path
     ) -> None:
-        """Tests that the summary panel is displayed with the correct stats."""
+        """Tests a successful two-pass import with deferred fields."""
         source_file = tmp_path / "source.csv"
         source_file.touch()
-        mock_import_data.return_value = (
-            True,
-            {"total_records": 10, "created_records": 8, "updated_relations": 2},
+        mock_import_data.return_value = (True, {"created_records": 2})
+
+        run_import(
+            config=str(source_file),
+            filename=str(source_file),
+            model="res.partner",
+            deferred_fields=["parent_id"],
+            unique_id_field="id",
+            no_preflight_checks=True,
+            headless=True,
+            worker=1,
+            batch_size=100,
+            skip=0,
+            fail=False,
+            separator=";",
+            ignore=[],
+            context={},
+            encoding="utf-8",
+            o2m=False,
+            groupby=None,
         )
-        test_args = TestRunImport.DEFAULT_ARGS.copy()
-        test_args["filename"] = str(source_file)
-        run_import(**test_args)
-        mock_panel.assert_called_once()
-        renderable = mock_panel.call_args[0][0]
-        assert (
-            "Import for [cyan]res.partner[/cyan] finished successfully." in renderable
-        )
+        mock_import_data.assert_called_once()
 
 
 @patch("odoo_data_flow.importer.import_threaded.import_data")
-def test_run_import_with_vies_disabled(
-    mock_import_data: MagicMock, tmp_path: Path
+@patch("odoo_data_flow.importer._run_preflight_checks", return_value=False)
+def test_run_import_preflight_fails(
+    mock_preflight: MagicMock, mock_import_data: MagicMock, tmp_path: Path
 ) -> None:
-    """Tests that the VIES check is disabled when the context is set."""
+    """Test that the import aborts if preflight checks fail."""
     source_file = tmp_path / "source.csv"
     source_file.touch()
-    mock_import_data.return_value = (True, {"total_records": 1})
-    test_args = TestRunImport.DEFAULT_ARGS.copy()
-    test_args["filename"] = str(source_file)
-    test_args["context"] = {"vat_check_vies": False}
-    run_import(**test_args)
-    mock_import_data.assert_called_once()
-    assert mock_import_data.call_args.kwargs["context"] == {"vat_check_vies": False}
-
-
-@patch("odoo_data_flow.importer.relational_import.run_direct_relational_import")
-@patch("odoo_data_flow.importer.import_threaded.import_data")
-@patch("odoo_data_flow.importer._run_preflight_checks")
-def test_run_import_orchestrates_direct_relational_strategy(
-    mock_preflight: MagicMock,
-    mock_import_data: MagicMock,
-    mock_relational_import: MagicMock,
-    tmp_path: Path,
-) -> None:
-    """Verify the importer correctly orchestrates the direct relational strategy."""
-    source_file = tmp_path / "source.csv"
-    source_file.write_text("id,name,category_id\n1,test,cat1")
-
-    # Create a dummy temp file for the relational import to return
-    relational_temp_file = tmp_path / "relational_temp.csv"
-    relational_temp_file.touch()
-
-    def preflight_side_effect(*args: Any, **kwargs: Any) -> bool:
-        kwargs["import_plan"]["strategies"] = {
-            "category_id": {
-                "strategy": "direct_relational_import",
-                "type": "many2many",
-                "relation_table": "res.partner.category.rel",
-                "relation_field": "partner_id",
-                "relation": "category_id",
-            }
-        }
-        return True
-
-    mock_preflight.side_effect = preflight_side_effect
-    mock_import_data.return_value = (True, {"id_map": {"p1": 1}})
-    mock_relational_import.return_value = {
-        "file_csv": str(relational_temp_file),
-        "model": "res.partner.category.rel",
-        "unique_id_field": "partner_id",
-    }
-
-    test_args = TestRunImport.DEFAULT_ARGS.copy()
-    test_args["filename"] = str(source_file)
-    test_args["no_preflight_checks"] = False
-
-    run_import(**test_args)
-    # The main import_data is called for the main file and for the relational file.
-    assert mock_import_data.call_count == 2
-    mock_relational_import.assert_called_once()
-    call_args = mock_relational_import.call_args[0]
-    assert call_args[1] == "res.partner"
-    assert call_args[2] == "category_id"
-
-
-@patch("odoo_data_flow.importer.relational_import.run_write_tuple_import")
-@patch("odoo_data_flow.importer.import_threaded.import_data")
-@patch("odoo_data_flow.importer._run_preflight_checks")
-def test_run_import_orchestrates_write_tuple_strategy(
-    mock_preflight: MagicMock,
-    mock_import_data: MagicMock,
-    mock_write_tuple_import: MagicMock,
-    tmp_path: Path,
-) -> None:
-    """Verify the importer correctly orchestrates the write tuple strategy."""
-    source_file = tmp_path / "source.csv"
-    source_file.write_text("id,name,category_id\n1,test,cat1")
-
-    def preflight_side_effect(*args: Any, **kwargs: Any) -> bool:
-        kwargs["import_plan"]["strategies"] = {
-            "category_id": {
-                "strategy": "write_tuple",
-                "type": "many2many",
-                "relation_table": "res.partner.category.rel",
-                "relation_field": "partner_id",
-                "relation": "category_id",
-            }
-        }
-        return True
-
-    mock_preflight.side_effect = preflight_side_effect
-    mock_import_data.return_value = (True, {"id_map": {"p1": 1}})
-
-    test_args = TestRunImport.DEFAULT_ARGS.copy()
-    test_args["filename"] = str(source_file)
-    test_args["no_preflight_checks"] = False
-
-    run_import(**test_args)
-    mock_import_data.assert_called_once()
-    mock_write_tuple_import.assert_called_once()
-    call_args = mock_write_tuple_import.call_args[0]
-    assert call_args[1] == "res.partner"
-    assert call_args[2] == "category_id"
-
-
-@patch("odoo_data_flow.importer.relational_import.run_write_o2m_tuple_import")
-@patch("odoo_data_flow.importer.relational_import.run_write_tuple_import")
-@patch("odoo_data_flow.importer.import_threaded.import_data")
-@patch("odoo_data_flow.importer._run_preflight_checks")
-def test_run_import_orchestrates_combined_strategies(
-    mock_preflight: MagicMock,
-    mock_import_data: MagicMock,
-    mock_write_tuple: MagicMock,
-    mock_write_o2m: MagicMock,
-    tmp_path: Path,
-) -> None:
-    """Verify the importer correctly orchestrates multiple strategies in one run."""
-    source_file = tmp_path / "source.csv"
-    source_file.write_text(
-        "id,name,parent_id,category_id,line_ids\n"
-        'p1,Parent,,cat1,"[{"product": "prodA"}]"\n'
-        "c1,Child,p1,cat2,\n"
+    run_import(
+        config="dummy.conf",
+        filename=str(source_file),
+        model="res.partner",
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        fail=False,
+        separator=";",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
     )
+    mock_import_data.assert_not_called()
+
+
+@patch("odoo_data_flow.importer.import_threaded.import_data")
+@patch("odoo_data_flow.importer._run_preflight_checks", return_value=True)
+def test_run_import_fail_mode(
+    mock_preflight: MagicMock, mock_import_data: MagicMock, tmp_path: Path
+) -> None:
+    """Test the fail mode logic."""
+    source_file = tmp_path / "source.csv"
+    source_file.touch()
+    fail_file = tmp_path / "res_partner_fail.csv"
+    fail_file.write_text("id,name\n1,test")
+    mock_import_data.return_value = (True, {"total_records": 1})
+
+    run_import(
+        config="dummy.conf",
+        filename=str(source_file),
+        model="res.partner",
+        fail=True,
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        separator=";",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    assert mock_import_data.call_args.kwargs["file_csv"] == str(fail_file)
+
+
+@patch("odoo_data_flow.importer.sort.sort_for_self_referencing")
+@patch("odoo_data_flow.importer.import_threaded.import_data")
+@patch("odoo_data_flow.importer._run_preflight_checks")
+def test_run_import_sort_strategy(
+    mock_preflight: MagicMock,
+    mock_import_data: MagicMock,
+    mock_sort: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test the sort and one pass load strategy."""
+    source_file = tmp_path / "source.csv"
+    source_file.touch()
+    sorted_file = tmp_path / "sorted.csv"
+    mock_sort.return_value = str(sorted_file)
 
     def preflight_side_effect(*args: Any, **kwargs: Any) -> bool:
-        import_plan = kwargs["import_plan"]
-        import_plan["deferred_fields"] = ["parent_id", "category_id", "line_ids"]
-        import_plan["strategies"] = {
-            "category_id": {
-                "strategy": "write_tuple",
-                "relation": "res.partner.category",
-            },
-            "line_ids": {"strategy": "write_o2m_tuple"},
-        }
+        kwargs["import_plan"]["strategy"] = "sort_and_one_pass_load"
+        kwargs["import_plan"]["id_column"] = "id"
+        kwargs["import_plan"]["parent_column"] = "parent_id"
         return True
 
     mock_preflight.side_effect = preflight_side_effect
-    mock_import_data.return_value = (True, {"id_map": {"p1": 1, "c1": 2}})
+    mock_import_data.return_value = (True, {"total_records": 1})
 
-    test_args = TestRunImport.DEFAULT_ARGS.copy()
-    test_args["filename"] = str(source_file)
-    test_args["no_preflight_checks"] = False
+    run_import(
+        config="dummy.conf",
+        filename=str(source_file),
+        model="res.partner",
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=False,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        fail=False,
+        separator=";",
+        ignore=None,
+        context={},
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    mock_sort.assert_called_once()
+    assert mock_import_data.call_args.kwargs["file_csv"] == str(sorted_file)
 
-    run_import(**test_args)
+
+@patch("odoo_data_flow.importer.import_threaded.import_data")
+def test_run_import_for_migration(mock_import_data: MagicMock) -> None:
+    """Test the run_import_for_migration function."""
+    mock_import_data.return_value = (True, {})
+    run_import_for_migration(
+        config="dummy.conf",
+        model="res.partner",
+        header=["id", "name"],
+        data=[[1, "test"]],
+    )
     mock_import_data.assert_called_once()
-    mock_write_tuple.assert_called_once()
-    mock_write_o2m.assert_called_once()
-    assert mock_write_tuple.call_args[0][2] == "category_id"
-    assert mock_write_o2m.call_args[0][2] == "line_ids"
+
+
+@patch("odoo_data_flow.importer._show_error_panel")
+def test_run_import_invalid_context(mock_show_error: MagicMock) -> None:
+    """Test that run_import handles invalid context."""
+    run_import(
+        config="dummy.conf",
+        filename="dummy.csv",
+        model="res.partner",
+        context="not a dict",
+        deferred_fields=None,
+        unique_id_field=None,
+        no_preflight_checks=True,
+        headless=True,
+        worker=1,
+        batch_size=100,
+        skip=0,
+        fail=False,
+        separator=";",
+        ignore=None,
+        encoding="utf-8",
+        o2m=False,
+        groupby=None,
+    )
+    mock_show_error.assert_called_once()

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -346,9 +346,7 @@ class TestLanguageCheck:
         assert result is True, "The check should return True in fail mode"
 
         # 1. Assert that the correct debug message was logged.
-        mock_log_debug.assert_called_once_with(
-            "Skipping language pre-flight check in --fail mode."
-        )
+        mock_log_debug.assert_called_once_with("Skipping language pre-flight check.")
 
         # 2. Assert that the function exited before doing any real work.
         mock_polars_read_csv.assert_not_called()

--- a/tests/test_relational_import.py
+++ b/tests/test_relational_import.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import polars as pl
+import pytest
 from polars.testing import assert_frame_equal
 from rich.progress import Progress
 
@@ -73,3 +74,134 @@ def test_run_direct_relational_import(
         assert_frame_equal(df, expected_df, check_row_order=False)
     finally:
         Path(temp_csv_path).unlink(missing_ok=True)
+
+
+@patch("odoo_data_flow.lib.relational_import.conf_lib.get_connection_from_config")
+@patch("odoo_data_flow.lib.relational_import._resolve_related_ids")
+def test_run_write_tuple_import(
+    mock_resolve_ids: MagicMock,
+    mock_get_conn: MagicMock,
+) -> None:
+    """Verify the write tuple import workflow."""
+    # Arrange
+    source_df = pl.DataFrame(
+        {
+            "id": ["p1", "p2"],
+            "name": ["Partner 1", "Partner 2"],
+            "category_id": ["cat1,cat2", "cat2,cat3"],
+        }
+    )
+    mock_resolve_ids.return_value = pl.DataFrame(
+        {"external_id": ["cat1", "cat2", "cat3"], "db_id": [11, 12, 13]}
+    )
+    mock_rel_model = MagicMock()
+    mock_get_conn.return_value.get_model.return_value = mock_rel_model
+
+    strategy_details = {
+        "relation_table": "res.partner.category.rel",
+        "relation_field": "partner_id",
+        "relation": "category_id",
+    }
+    id_map = {"p1": 1, "p2": 2}
+    progress = Progress()
+    task_id = progress.add_task("test")
+
+    # Act
+    result = relational_import.run_write_tuple_import(
+        "dummy.conf",
+        "res.partner",
+        "category_id",
+        strategy_details,
+        source_df,
+        id_map,
+        1,
+        10,
+        progress,
+        task_id,
+        "source.csv",
+    )
+
+    # Assert
+    assert result is True
+    assert mock_rel_model.create.call_count == 1
+
+
+@patch("odoo_data_flow.lib.relational_import.cache.load_id_map", return_value=None)
+@patch("odoo_data_flow.lib.relational_import.conf_lib.get_connection_from_config")
+def test_resolve_related_ids_failure(
+    mock_get_conn: MagicMock,
+    mock_load_id_map: MagicMock,
+) -> None:
+    """Test that _resolve_related_ids returns None on failure."""
+    mock_get_conn.return_value.get_model.return_value.search_read.return_value = []
+    result = relational_import._resolve_related_ids(
+        "dummy.conf", "res.partner", pl.Series(["p1"])
+    )
+    assert result is None
+
+
+@patch("odoo_data_flow.lib.relational_import.conf_lib.get_connection_from_dict")
+def test_resolve_related_ids_with_dict(mock_get_conn_dict: MagicMock) -> None:
+    """Test _resolve_related_ids with a dictionary config."""
+    mock_get_conn_dict.return_value.get_model.return_value.search_read.return_value = []
+    result = relational_import._resolve_related_ids(
+        {"host": "localhost"}, "res.partner", pl.Series(["p1.p1"])
+    )
+    assert result is None
+
+
+@patch("odoo_data_flow.lib.relational_import.cache.load_id_map", return_value=None)
+@patch(
+    "odoo_data_flow.lib.relational_import.conf_lib.get_connection_from_config",
+    side_effect=Exception("Connection failed"),
+)
+def test_resolve_related_ids_connection_error(
+    mock_get_conn: MagicMock,
+    mock_load_id_map: MagicMock,
+) -> None:
+    """Test that _resolve_related_ids returns None on connection error."""
+    with pytest.raises(Exception, match="Connection failed"):
+        relational_import._resolve_related_ids(
+            "dummy.conf", "res.partner", pl.Series(["p1.p1"])
+        )
+
+
+@patch("odoo_data_flow.lib.relational_import.conf_lib.get_connection_from_config")
+def test_run_write_o2m_tuple_import(mock_get_conn: MagicMock) -> None:
+    """Verify the o2m tuple import workflow."""
+    # Arrange
+    source_df = pl.DataFrame(
+        {
+            "id": ["p1"],
+            "name": ["Partner 1"],
+            "line_ids": ['[{"product": "prodA", "qty": 1}]'],
+        }
+    )
+    mock_parent_model = MagicMock()
+    mock_get_conn.return_value.get_model.return_value = mock_parent_model
+
+    strategy_details: dict[str, str] = {}
+    id_map = {"p1": 1}
+    progress = Progress()
+    task_id = progress.add_task("test")
+
+    # Act
+    result = relational_import.run_write_o2m_tuple_import(
+        "dummy.conf",
+        "res.partner",
+        "line_ids",
+        strategy_details,
+        source_df,
+        id_map,
+        1,
+        10,
+        progress,
+        task_id,
+        "source.csv",
+    )
+
+    # Assert
+    assert result is True
+    mock_parent_model.write.assert_called_once_with(
+        [1], {"line_ids": [(0, 0, {"product": "prodA", "qty": 1})]}
+    )


### PR DESCRIPTION
The CLI now defaults to a project-based workflow, looking for `flows.yml`. Single-action commands like `export` and `import` are still available but now require a `--connection-file` argument for clarity.

The core logic has been updated so that functions like `run_export` can be called with a dictionary, allowing for easier integration as a library within an Odoo module.

Tests have been updated and added to ensure coverage for the new functionality.